### PR TITLE
chore(workflows): add support for arm64 linux binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,14 @@ jobs:
             target: x86_64-unknown-linux-musl
             build: pnpm core:build
           
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            build: pnpm core:build
+          
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            build: pnpm core:build
+          
           - os: macos-latest
             target: x86_64-apple-darwin
             build: pnpm core:build


### PR DESCRIPTION
Build napi for arm64/aarch64 linux as well, making kito available on platforms like RPi 5 or Asahi Linux.

I manually tested the addition to this workflow by running it in GitHub's Actions runner.

Also note that we do need `ubuntu-24.04-arm` or at least it's the last mention of arm64 linux targets GitHub [explicitly mentioned](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/).