### PR TITLE
fix(server): update catch-all to `/{*path}` and suppress conflict panic

### DIFF
--- a/packages/kitojs/src/server/server.ts
+++ b/packages/kitojs/src/server/server.ts
@@ -301,13 +301,17 @@ export class KitoServer<TExtensions = {}>
     ];
 
     for (const method of methods) {
-      this.coreServer.addRoute({
-        method,
-        path: "{*path}",
-        handler: routeHandler,
-        schema: undefined,
-        staticResponse: undefined,
-      });
+      try {
+        this.coreServer.addRoute({
+          method,
+          path: "/{*path}",
+          handler: routeHandler,
+          schema: undefined,
+          staticResponse: undefined,
+        });
+      } catch (e) {
+        // Suppress conflict error
+      }
     }
   }
 


### PR DESCRIPTION
### Problem

When adding a wildcard node (`{*path}`) at the same level as an existing parameter node (`/{foo}`), matchit attempts to detect this forbidden conflict. It should return a conflict error. However, because `{*path}` is missing the leading slash, it has 0 common characters with the existing route. The matchit logic blindly checks the character before the common part (index - 1), causing an integer underflow panic (crash) instead of returning the proper error. (#34)

### Solution

Since the upstream matchit library has not yet resolved the integer underflow bug, I changed the default catch-all registration to `/{*path}`. Crucially, it avoids the crash path in matchit. Instead of panicking, it throws a standard conflict error.
We wrapped this registration in a try-catch block. This allows us to catch that conflict error and prevent the server from crashing when a parameter node (e.g., `/:id`) is present.

