### PR TITLE
fix(kitojs): correct route chaining overloads and fix schema application

### DIFF
--- a/packages/kitojs/src/server/router.ts
+++ b/packages/kitojs/src/server/router.ts
@@ -512,8 +512,7 @@ export class KitoRouter<TExtensions = {}>
           | (MiddlewareDefinition | TSchema)[]
           | (MiddlewareDefinition | TSchema)
           | RouteHandler<TSchema, TExtensions>,
-        handler?: RouteHandler<TSchema, TExtensions>,
-        schema?: TSchema,
+        handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
       ): RouteChain<TExtensions> {
         if (typeof middlewaresOrHandler === "function") {
           self.addRoute(
@@ -521,15 +520,14 @@ export class KitoRouter<TExtensions = {}>
             path,
             mergeMiddlewares<TSchema>(),
             middlewaresOrHandler,
-            schema,
+            handlerOrSchema as TSchema,
           );
         } else {
           self.addRoute(
             "GET",
             path,
             mergeMiddlewares<TSchema>(middlewaresOrHandler),
-            handler,
-            schema,
+            handlerOrSchema as RouteHandler<TSchema, TExtensions>,
           );
         }
         return chain;
@@ -541,8 +539,7 @@ export class KitoRouter<TExtensions = {}>
           | (MiddlewareDefinition | TSchema)[]
           | (MiddlewareDefinition | TSchema)
           | RouteHandler<TSchema, TExtensions>,
-        handler?: RouteHandler<TSchema, TExtensions>,
-        schema?: TSchema,
+        handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
       ): RouteChain<TExtensions> {
         if (typeof middlewaresOrHandler === "function") {
           self.addRoute(
@@ -550,15 +547,14 @@ export class KitoRouter<TExtensions = {}>
             path,
             mergeMiddlewares<TSchema>(),
             middlewaresOrHandler,
-            schema,
+            handlerOrSchema as TSchema,
           );
         } else {
           self.addRoute(
             "POST",
             path,
             mergeMiddlewares<TSchema>(middlewaresOrHandler),
-            handler,
-            schema,
+            handlerOrSchema as RouteHandler<TSchema, TExtensions>,
           );
         }
         return chain;
@@ -570,8 +566,7 @@ export class KitoRouter<TExtensions = {}>
           | (MiddlewareDefinition | TSchema)[]
           | (MiddlewareDefinition | TSchema)
           | RouteHandler<TSchema, TExtensions>,
-        handler?: RouteHandler<TSchema, TExtensions>,
-        schema?: TSchema,
+        handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
       ): RouteChain<TExtensions> {
         if (typeof middlewaresOrHandler === "function") {
           self.addRoute(
@@ -579,15 +574,14 @@ export class KitoRouter<TExtensions = {}>
             path,
             mergeMiddlewares<TSchema>(),
             middlewaresOrHandler,
-            schema,
+            handlerOrSchema as TSchema,
           );
         } else {
           self.addRoute(
             "PUT",
             path,
             mergeMiddlewares<TSchema>(middlewaresOrHandler),
-            handler,
-            schema,
+            handlerOrSchema as RouteHandler<TSchema, TExtensions>,
           );
         }
         return chain;
@@ -599,8 +593,7 @@ export class KitoRouter<TExtensions = {}>
           | (MiddlewareDefinition | TSchema)[]
           | (MiddlewareDefinition | TSchema)
           | RouteHandler<TSchema, TExtensions>,
-        handler?: RouteHandler<TSchema, TExtensions>,
-        schema?: TSchema,
+        handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
       ): RouteChain<TExtensions> {
         if (typeof middlewaresOrHandler === "function") {
           self.addRoute(
@@ -608,15 +601,14 @@ export class KitoRouter<TExtensions = {}>
             path,
             mergeMiddlewares<TSchema>(),
             middlewaresOrHandler,
-            schema,
+            handlerOrSchema as TSchema,
           );
         } else {
           self.addRoute(
             "DELETE",
             path,
             mergeMiddlewares<TSchema>(middlewaresOrHandler),
-            handler,
-            schema,
+            handlerOrSchema as RouteHandler<TSchema, TExtensions>,
           );
         }
         return chain;
@@ -628,8 +620,7 @@ export class KitoRouter<TExtensions = {}>
           | (MiddlewareDefinition | TSchema)[]
           | (MiddlewareDefinition | TSchema)
           | RouteHandler<TSchema, TExtensions>,
-        handler?: RouteHandler<TSchema, TExtensions>,
-        schema?: TSchema,
+        handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
       ): RouteChain<TExtensions> {
         if (typeof middlewaresOrHandler === "function") {
           self.addRoute(
@@ -637,15 +628,14 @@ export class KitoRouter<TExtensions = {}>
             path,
             mergeMiddlewares<TSchema>(),
             middlewaresOrHandler,
-            schema,
+            handlerOrSchema as TSchema,
           );
         } else {
           self.addRoute(
             "PATCH",
             path,
             mergeMiddlewares<TSchema>(middlewaresOrHandler),
-            handler,
-            schema,
+            handlerOrSchema as RouteHandler<TSchema, TExtensions>,
           );
         }
         return chain;
@@ -657,8 +647,7 @@ export class KitoRouter<TExtensions = {}>
           | (MiddlewareDefinition | TSchema)[]
           | (MiddlewareDefinition | TSchema)
           | RouteHandler<TSchema, TExtensions>,
-        handler?: RouteHandler<TSchema, TExtensions>,
-        schema?: TSchema,
+        handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
       ): RouteChain<TExtensions> {
         if (typeof middlewaresOrHandler === "function") {
           self.addRoute(
@@ -666,15 +655,14 @@ export class KitoRouter<TExtensions = {}>
             path,
             mergeMiddlewares<TSchema>(),
             middlewaresOrHandler,
-            schema,
+            handlerOrSchema as TSchema,
           );
         } else {
           self.addRoute(
             "OPTIONS",
             path,
             mergeMiddlewares<TSchema>(middlewaresOrHandler),
-            handler,
-            schema,
+            handlerOrSchema as RouteHandler<TSchema, TExtensions>,
           );
         }
         return chain;
@@ -686,8 +674,7 @@ export class KitoRouter<TExtensions = {}>
           | (MiddlewareDefinition | TSchema)[]
           | (MiddlewareDefinition | TSchema)
           | RouteHandler<TSchema, TExtensions>,
-        handler?: RouteHandler<TSchema, TExtensions>,
-        schema?: TSchema,
+        handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
       ): RouteChain<TExtensions> {
         if (typeof middlewaresOrHandler === "function") {
           self.addRoute(
@@ -695,15 +682,14 @@ export class KitoRouter<TExtensions = {}>
             path,
             mergeMiddlewares<TSchema>(),
             middlewaresOrHandler,
-            schema,
+            handlerOrSchema as TSchema,
           );
         } else {
           self.addRoute(
             "HEAD",
             path,
             mergeMiddlewares<TSchema>(middlewaresOrHandler),
-            handler,
-            schema,
+            handlerOrSchema as RouteHandler<TSchema, TExtensions>,
           );
         }
         return chain;

--- a/packages/kitojs/tests/route-chain.test.ts
+++ b/packages/kitojs/tests/route-chain.test.ts
@@ -1,0 +1,206 @@
+import type { SchemaDefinition } from "@kitojs/types";
+import { describe, expect, it, vi } from "vitest";
+import { middleware, router, server } from "../src";
+
+describe("Route Chaining", () => {
+  describe("Server Chaining", () => {
+    it("should support fluent API (method chaining)", () => {
+      const app = server();
+      expect(() => {
+        app
+          .get("/", (ctx) => ctx.res.send("home"))
+          .post("/users", (ctx) => ctx.res.json({ created: true }))
+          .get("/about", (ctx) => ctx.res.send("about"));
+      }).not.toThrow();
+
+      // biome-ignore lint/complexity/useLiteralKeys: ...
+      const routes = app["routes"];
+      expect(routes).toHaveLength(3);
+    });
+
+    it("should use route() builder", () => {
+      const app = server();
+      const routes = app.route("/api");
+
+      expect(typeof routes.get).toBe("function");
+      expect(typeof routes.post).toBe("function");
+      expect(typeof routes.end).toBe("function");
+    });
+
+    it("should chain routes and end", () => {
+      const app = server();
+      expect(() => {
+        app
+          .route("/api")
+          .get((ctx) => ctx.res.send("get"))
+          .post((ctx) => ctx.res.send("post"))
+          .end()
+          .get("/", (ctx) => ctx.res.send("home"));
+      }).not.toThrow();
+
+      // biome-ignore lint/complexity/useLiteralKeys: ...
+      const routes = app["routes"];
+      expect(routes).toHaveLength(3);
+    });
+
+    it("should work correctly with server().route() chaining and core registration", async () => {
+      const app = server();
+      // biome-ignore lint/complexity/useLiteralKeys: ...
+      const spy = vi.spyOn(app["coreServer"], "addRoute");
+
+      app
+        .route("/direct")
+        .get((ctx) => ctx.res.send("get"))
+        .post((ctx) => ctx.res.send("post"));
+
+      // biome-ignore lint/complexity/useLiteralKeys: ...
+      const routes = app["routes"];
+      expect(
+        routes.find((r) => r.path === "/direct" && r.method === "GET"),
+      ).toBeDefined();
+      expect(
+        routes.find((r) => r.path === "/direct" && r.method === "POST"),
+      ).toBeDefined();
+
+      // Verify it's actually registered in the core server via spy
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ path: "/direct", method: "GET" }),
+      );
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ path: "/direct", method: "POST" }),
+      );
+    });
+
+    it("should correctly handle schema in server().route() chaining", () => {
+      const app = server();
+      // biome-ignore lint/complexity/useLiteralKeys: ...
+      const spy = vi.spyOn(app["coreServer"], "addRoute");
+
+      // Use proper schema builder mock
+      const userSchema = {
+        params: {
+          _serialize: () => JSON.stringify({ id: "string" }),
+        },
+      };
+
+      app.route("/search").get((ctx) => ctx.res.send("ok"), userSchema as any);
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: "/search",
+          method: "GET",
+          schema: JSON.stringify({ params: JSON.stringify({ id: "string" }) }),
+        }),
+      );
+    });
+  });
+
+  describe("Router Chaining", () => {
+    it("should handle route chaining", () => {
+      const r = router();
+      r.route("/users")
+        .get((ctx) => ctx.res.send("list"))
+        .post((ctx) => ctx.res.send("create"));
+
+      // biome-ignore lint/complexity/useLiteralKeys: ...
+      const routes = r["routes"];
+      expect(
+        routes.find((r) => r.method === "GET" && r.path === "/users"),
+      ).toBeDefined();
+      expect(
+        routes.find((r) => r.method === "POST" && r.path === "/users"),
+      ).toBeDefined();
+    });
+
+    it("should support all HTTP methods in a chain", () => {
+      const r = router();
+      r.route("/multi")
+        .get((ctx) => ctx.res.send("get"))
+        .post((ctx) => ctx.res.send("post"))
+        .put((ctx) => ctx.res.send("put"))
+        .delete((ctx) => ctx.res.send("delete"))
+        .patch((ctx) => ctx.res.send("patch"))
+        .head((ctx) => ctx.res.send("head"))
+        .options((ctx) => ctx.res.send("options"));
+
+      // biome-ignore lint/complexity/useLiteralKeys: ...
+      const routes = r["routes"];
+      expect(routes).toHaveLength(7);
+      const methods = routes.map((r) => r.method);
+      expect(methods).toContain("GET");
+      expect(methods).toContain("POST");
+      expect(methods).toContain("PUT");
+      expect(methods).toContain("DELETE");
+      expect(methods).toContain("PATCH");
+      expect(methods).toContain("HEAD");
+      expect(methods).toContain("OPTIONS");
+    });
+
+    it("should apply route-level middlewares to all methods in the chain", () => {
+      const mw = middleware((_ctx, next) => next());
+      const r = router();
+      r.route("/chain-mw", [mw])
+        .get((ctx) => ctx.res.send("ok"))
+        .post((ctx) => ctx.res.send("ok"));
+
+      // biome-ignore lint/complexity/useLiteralKeys: ...
+      const routes = r["routes"];
+      expect(routes[0].middlewares).toHaveLength(1);
+      expect(routes[1].middlewares).toHaveLength(1);
+      expect(routes[0].middlewares[0]).toBe(mw);
+      expect(routes[1].middlewares[0]).toBe(mw);
+    });
+
+    it("should correctly combine route-level and method-level middlewares", () => {
+      const routeMw = middleware((_ctx, next) => next());
+      const methodMw = middleware((_ctx, next) => next());
+      const r = router();
+
+      r.route("/combined", [routeMw]).get([methodMw], (ctx) =>
+        ctx.res.send("ok"),
+      );
+
+      // biome-ignore lint/complexity/useLiteralKeys: ...
+      const routes = r["routes"];
+      expect(routes[0].middlewares).toHaveLength(2);
+      expect(routes[0].middlewares[0]).toBe(routeMw);
+      expect(routes[0].middlewares[1]).toBe(methodMw);
+    });
+
+    it("should support schema application for individual methods in a chain", () => {
+      const schema = { params: { id: "string" } };
+      const r = router();
+
+      r.route("/schema").get(
+        (ctx) => ctx.res.send("ok"),
+        schema as unknown as SchemaDefinition,
+      );
+
+      // biome-ignore lint/complexity/useLiteralKeys: ...
+      const routes = r["routes"];
+      // middlewares should contain the schema if provided
+      expect(routes[0].middlewares).toContain(schema);
+    });
+
+    it("should work correctly when the router is mounted on a server", () => {
+      const sub = router();
+      sub
+        .route("/resource")
+        .get((ctx) => ctx.res.send("get"))
+        .post((ctx) => ctx.res.send("post"));
+
+      const app = server();
+      app.mount("/api", sub);
+
+      // biome-ignore lint/complexity/useLiteralKeys: ...
+      const routes = app["routes"];
+      expect(
+        routes.find((r) => r.path === "/api/resource" && r.method === "GET"),
+      ).toBeDefined();
+      expect(
+        routes.find((r) => r.path === "/api/resource" && r.method === "POST"),
+      ).toBeDefined();
+    });
+  });
+});

--- a/packages/kitojs/tests/server.test.ts
+++ b/packages/kitojs/tests/server.test.ts
@@ -127,36 +127,6 @@ describe("Server", () => {
     });
   });
 
-  describe("Route Chaining", () => {
-    it("should support fluent API", () => {
-      expect(() => {
-        app
-          .get("/", (ctx) => ctx.res.send("home"))
-          .post("/users", (ctx) => ctx.res.json({ created: true }))
-          .get("/about", (ctx) => ctx.res.send("about"));
-      }).not.toThrow();
-    });
-
-    it("should use route() builder", () => {
-      const routes = app.route("/api");
-
-      expect(typeof routes.get).toBe("function");
-      expect(typeof routes.post).toBe("function");
-      expect(typeof routes.end).toBe("function");
-    });
-
-    it("should chain routes and end", () => {
-      expect(() => {
-        app
-          .route("/api")
-          .get((ctx) => ctx.res.send("get"))
-          .post((ctx) => ctx.res.send("post"))
-          .end()
-          .get("/", (ctx) => ctx.res.send("home"));
-      }).not.toThrow();
-    });
-  });
-
   describe("Extension", () => {
     it("should extend context", () => {
       const extendedApp = app.extend<{ db: { query: () => string } }>((ctx) => {

--- a/packages/types/src/routes.d.ts
+++ b/packages/types/src/routes.d.ts
@@ -50,7 +50,7 @@ export type RouteChain<TExtensions = {}> = {
       | (MiddlewareDefinition | TSchema)[]
       | (MiddlewareDefinition | TSchema)
       | RouteHandler<TSchema, TExtensions>,
-    handler?: RouteHandler<TSchema, TExtensions> | TSchema,
+    handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
   ): RouteChain<TExtensions>;
 
   // biome-ignore lint/complexity/noBannedTypes: ...
@@ -75,7 +75,7 @@ export type RouteChain<TExtensions = {}> = {
       | (MiddlewareDefinition | TSchema)[]
       | (MiddlewareDefinition | TSchema)
       | RouteHandler<TSchema, TExtensions>,
-    handler?: RouteHandler<TSchema, TExtensions> | TSchema,
+    handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
   ): RouteChain<TExtensions>;
 
   // biome-ignore lint/complexity/noBannedTypes: ...
@@ -100,7 +100,7 @@ export type RouteChain<TExtensions = {}> = {
       | (MiddlewareDefinition | TSchema)[]
       | (MiddlewareDefinition | TSchema)
       | RouteHandler<TSchema, TExtensions>,
-    handler?: RouteHandler<TSchema, TExtensions> | TSchema,
+    handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
   ): RouteChain<TExtensions>;
 
   // biome-ignore lint/complexity/noBannedTypes: ...
@@ -125,7 +125,7 @@ export type RouteChain<TExtensions = {}> = {
       | (MiddlewareDefinition | TSchema)[]
       | (MiddlewareDefinition | TSchema)
       | RouteHandler<TSchema, TExtensions>,
-    handler?: RouteHandler<TSchema, TExtensions> | TSchema,
+    handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
   ): RouteChain<TExtensions>;
 
   // biome-ignore lint/complexity/noBannedTypes: ...
@@ -150,7 +150,7 @@ export type RouteChain<TExtensions = {}> = {
       | (MiddlewareDefinition | TSchema)[]
       | (MiddlewareDefinition | TSchema)
       | RouteHandler<TSchema, TExtensions>,
-    handler?: RouteHandler<TSchema, TExtensions> | TSchema,
+    handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
   ): RouteChain<TExtensions>;
 
   // biome-ignore lint/complexity/noBannedTypes: ...
@@ -175,7 +175,7 @@ export type RouteChain<TExtensions = {}> = {
       | (MiddlewareDefinition | TSchema)[]
       | (MiddlewareDefinition | TSchema)
       | RouteHandler<TSchema, TExtensions>,
-    handler?: RouteHandler<TSchema, TExtensions> | TSchema,
+    handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
   ): RouteChain<TExtensions>;
 
   // biome-ignore lint/complexity/noBannedTypes: ...
@@ -200,7 +200,7 @@ export type RouteChain<TExtensions = {}> = {
       | (MiddlewareDefinition | TSchema)[]
       | (MiddlewareDefinition | TSchema)
       | RouteHandler<TSchema, TExtensions>,
-    handler?: RouteHandler<TSchema, TExtensions> | TSchema,
+    handlerOrSchema?: RouteHandler<TSchema, TExtensions> | TSchema,
   ): RouteChain<TExtensions>;
 
   end(): KitoRouterInstance<TExtensions>;


### PR DESCRIPTION
### Issue

- Validation is not applied when using route chaining with `(handler, schema)`
```ts
app.route('/api/secure').get((ctx) => {
  ctx.res.send('Success');
}, schema({
  query: t.object({ token: t.str() })
}));
```

### Changes

- Used type narrowing to explicitly detect if the input is a handler or a schema, ensuring validation data always reaches the server.
- Add test cases for route chaining