### PR TITLE
feat: implement multipart/form-data file upload support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "matchit",
+ "multer",
  "napi",
  "napi-build",
  "napi-derive",
@@ -244,6 +245,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2",
+ "tempfile",
  "tokio",
  "tokio-test",
  "urlencoding",
@@ -317,10 +319,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fnv"
@@ -596,6 +623,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +650,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +673,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -842,6 +898,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +1003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1044,19 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -27,6 +27,7 @@ ahash = "0.8.12"
 base64 = "0.22.1"
 socket2 = "0.6.1"
 futures-util = "0.3.31"
+multer = "3.1.0"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -28,6 +28,7 @@ base64 = "0.22.1"
 socket2 = "0.6.1"
 futures-util = "0.3.31"
 multer = "3.1.0"
+tempfile = "3"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/packages/core/src/http.rs
+++ b/packages/core/src/http.rs
@@ -4,5 +4,6 @@ pub mod files;
 pub mod mime;
 pub mod mime_tests;
 pub mod multipart;
+pub mod multipart_tests;
 pub mod request;
 pub mod response;

--- a/packages/core/src/http.rs
+++ b/packages/core/src/http.rs
@@ -3,5 +3,6 @@ pub mod cookies_tests;
 pub mod files;
 pub mod mime;
 pub mod mime_tests;
+pub mod multipart;
 pub mod request;
 pub mod response;

--- a/packages/core/src/http/multipart.rs
+++ b/packages/core/src/http/multipart.rs
@@ -1,45 +1,189 @@
+use futures_util::StreamExt;
 use hyper::body::Bytes;
 use multer::Multipart;
 use std::collections::HashMap;
-use futures_util::stream::once;
-use std::convert::Infallible;
+use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
+use tokio::io::AsyncWriteExt;
+
+const DEFAULT_MEMORY_THRESHOLD: usize = 10 * 1024 * 1024;
+const DEFAULT_MAX_FILE_SIZE: usize = 100 * 1024 * 1024;
+const DEFAULT_MAX_TOTAL_SIZE: usize = 500 * 1024 * 1024;
+
+#[derive(Clone, Debug)]
+pub struct UploadConfig {
+    pub memory_threshold: usize,
+    pub max_file_size: usize,
+    pub max_total_size: usize,
+    pub temp_dir: Option<String>,
+}
+
+impl Default for UploadConfig {
+    fn default() -> Self {
+        Self {
+            memory_threshold: DEFAULT_MEMORY_THRESHOLD,
+            max_file_size: DEFAULT_MAX_FILE_SIZE,
+            max_total_size: DEFAULT_MAX_TOTAL_SIZE,
+            temp_dir: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum FileData {
+    Memory(Bytes),
+    Disk(PathBuf),
+}
+
+impl FileData {
+    pub fn as_bytes(&self) -> Option<&Bytes> {
+        match self {
+            FileData::Memory(b) => Some(b),
+            FileData::Disk(_) => None,
+        }
+    }
+
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            FileData::Memory(_) => None,
+            FileData::Disk(p) => Some(p),
+        }
+    }
+
+    pub fn is_disk(&self) -> bool {
+        matches!(self, FileData::Disk(_))
+    }
+
+    pub fn is_memory(&self) -> bool {
+        matches!(self, FileData::Memory(_))
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct UploadedFile {
     pub filename: String,
     pub content_type: String,
     pub size: usize,
-    pub data: Bytes,
+    pub data: FileData,
+}
+
+impl UploadedFile {
+    pub fn bytes(&self) -> Option<Bytes> {
+        match &self.data {
+            FileData::Memory(b) => Some(b.clone()),
+            FileData::Disk(_) => None,
+        }
+    }
+
+    pub fn path(&self) -> Option<&Path> {
+        match &self.data {
+            FileData::Memory(_) => None,
+            FileData::Disk(p) => Some(p),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum UploadError {
+    SizeLimitExceeded {
+        field: String,
+        limit: usize,
+        actual: usize,
+    },
+    TotalSizeExceeded { limit: usize, actual: usize },
+    IoError(std::io::Error),
+    MultipartError(multer::Error),
+}
+
+impl std::fmt::Display for UploadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UploadError::SizeLimitExceeded {
+                field,
+                limit,
+                actual,
+            } => write!(
+                f,
+                "File '{}' exceeds size limit: {} > {}",
+                field, actual, limit
+            ),
+            UploadError::TotalSizeExceeded { limit, actual } => {
+                write!(
+                    f,
+                    "Total upload size exceeds limit: {} > {}",
+                    actual, limit
+                )
+            }
+            UploadError::IoError(e) => write!(f, "IO error: {}", e),
+            UploadError::MultipartError(e) => write!(f, "Multipart error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for UploadError {}
+
+impl From<multer::Error> for UploadError {
+    fn from(e: multer::Error) -> Self {
+        UploadError::MultipartError(e)
+    }
+}
+
+impl From<std::io::Error> for UploadError {
+    fn from(e: std::io::Error) -> Self {
+        UploadError::IoError(e)
+    }
+}
+
+pub fn extract_boundary(content_type: &str) -> Option<String> {
+    if !content_type.to_lowercase().starts_with("multipart/form-data") {
+        return None;
+    }
+
+    content_type.split(';').find_map(|s| {
+        let s = s.trim();
+        let (key, value) = s.split_once('=')?;
+        if key.trim().to_lowercase() == "boundary" {
+            Some(value.trim().trim_matches('"').to_string())
+        } else {
+            None
+        }
+    })
 }
 
 pub async fn parse_multipart(
     boundary: &str,
     data: Bytes,
-) -> Result<(HashMap<String, Vec<String>>, HashMap<String, Vec<UploadedFile>>), multer::Error> {
-    let stream = once(async move { Result::<Bytes, Infallible>::Ok(data) });
+    config: &UploadConfig,
+) -> Result<
+    (
+        HashMap<String, Vec<String>>,
+        HashMap<String, Vec<UploadedFile>>,
+    ),
+    UploadError,
+> {
+    let stream = futures_util::stream::once(async { Ok::<Bytes, std::io::Error>(data) });
     let mut multipart = Multipart::new(stream, boundary);
 
     let mut fields: HashMap<String, Vec<String>> = HashMap::new();
     let mut files: HashMap<String, Vec<UploadedFile>> = HashMap::new();
+    let mut total_size: usize = 0;
 
     while let Some(field) = multipart.next_field().await? {
         let name = field.name().unwrap_or_default().to_string();
         let filename = field.file_name().map(|s| {
-            // Sanitize filename: remove path components
             let s = s.split(['/', '\\']).last().unwrap_or(s);
             s.to_string()
         });
-        let content_type = field.content_type().map(|m| m.to_string()).unwrap_or_else(|| "application/octet-stream".to_string());
+        let content_type = field
+            .content_type()
+            .map(|m| m.to_string())
+            .unwrap_or_else(|| "application/octet-stream".to_string());
 
         if let Some(filename) = filename {
-            let data = field.bytes().await?;
-            let size = data.len();
-            files.entry(name).or_default().push(UploadedFile {
-                filename,
-                content_type,
-                size,
-                data,
-            });
+            let uploaded =
+                process_file_field(&name, &filename, &content_type, field, config, &mut total_size)
+                    .await?;
+            files.entry(name).or_default().push(uploaded);
         } else {
             let value = field.text().await?;
             fields.entry(name).or_default().push(value);
@@ -47,4 +191,101 @@ pub async fn parse_multipart(
     }
 
     Ok((fields, files))
+}
+
+async fn process_file_field(
+    field_name: &str,
+    filename: &str,
+    content_type: &str,
+    mut field: multer::Field<'_>,
+    config: &UploadConfig,
+    total_size: &mut usize,
+) -> Result<UploadedFile, UploadError> {
+    let mut in_memory: Vec<u8> = Vec::new();
+    let mut temp_file: Option<NamedTempFile> = None;
+    let mut file_size: usize = 0;
+    let mut writer: Option<tokio::io::BufWriter<tokio::fs::File>> = None;
+
+    while let Some(chunk) = field.next().await {
+        let chunk = chunk?;
+        let chunk_len = chunk.len();
+
+        if file_size + chunk_len > config.max_file_size {
+            return Err(UploadError::SizeLimitExceeded {
+                field: field_name.to_string(),
+                limit: config.max_file_size,
+                actual: file_size + chunk_len,
+            });
+        }
+
+        if *total_size + chunk_len > config.max_total_size {
+            return Err(UploadError::TotalSizeExceeded {
+                limit: config.max_total_size,
+                actual: *total_size + chunk_len,
+            });
+        }
+
+        if temp_file.is_none() && file_size + chunk_len <= config.memory_threshold {
+            in_memory.extend_from_slice(&chunk);
+        } else {
+            if temp_file.is_none() {
+                let tf = create_temp_file(config.temp_dir.as_deref())?;
+                let f = tf.reopen()?;
+                let mut buf = tokio::io::BufWriter::new(tokio::fs::File::from_std(f));
+                if !in_memory.is_empty() {
+                    buf.write_all(&in_memory).await?;
+                    in_memory.clear();
+                }
+                writer = Some(buf);
+                temp_file = Some(tf);
+            }
+
+            if let Some(ref mut w) = writer {
+                w.write_all(&chunk).await?;
+            }
+        }
+
+        file_size += chunk_len;
+        *total_size += chunk_len;
+    }
+
+    let data = if let Some(tf) = temp_file {
+        if let Some(ref mut w) = writer {
+            w.flush().await?;
+        }
+        let path = tf.into_temp_path();
+        let path = path.keep().map_err(std::io::Error::from)?;
+        FileData::Disk(path)
+    } else {
+        FileData::Memory(Bytes::from(in_memory))
+    };
+
+    Ok(UploadedFile {
+        filename: filename.to_string(),
+        content_type: content_type.to_string(),
+        size: file_size,
+        data,
+    })
+}
+
+fn create_temp_file(temp_dir: Option<&str>) -> Result<NamedTempFile, std::io::Error> {
+    let builder = tempfile::Builder::new();
+    match temp_dir {
+        Some(dir) => builder.tempfile_in(dir),
+        None => builder.tempfile(),
+    }
+}
+
+pub fn cleanup_file(file: &UploadedFile) {
+    if let FileData::Disk(path) = &file.data {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+pub fn cleanup_files(files: &HashMap<String, Vec<UploadedFile>>) {
+    for file_list in files.values() {
+        for file in file_list {
+            cleanup_file(file);
+        }
+    }
 }

--- a/packages/core/src/http/multipart.rs
+++ b/packages/core/src/http/multipart.rs
@@ -85,11 +85,7 @@ impl UploadedFile {
 
 #[derive(Debug)]
 pub enum UploadError {
-    SizeLimitExceeded {
-        field: String,
-        limit: usize,
-        actual: usize,
-    },
+    SizeLimitExceeded { field: String, limit: usize, actual: usize },
     TotalSizeExceeded { limit: usize, actual: usize },
     IoError(std::io::Error),
     MultipartError(multer::Error),
@@ -98,21 +94,11 @@ pub enum UploadError {
 impl std::fmt::Display for UploadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UploadError::SizeLimitExceeded {
-                field,
-                limit,
-                actual,
-            } => write!(
-                f,
-                "File '{}' exceeds size limit: {} > {}",
-                field, actual, limit
-            ),
+            UploadError::SizeLimitExceeded { field, limit, actual } => {
+                write!(f, "File '{}' exceeds size limit: {} > {}", field, actual, limit)
+            }
             UploadError::TotalSizeExceeded { limit, actual } => {
-                write!(
-                    f,
-                    "Total upload size exceeds limit: {} > {}",
-                    actual, limit
-                )
+                write!(f, "Total upload size exceeds limit: {} > {}", actual, limit)
             }
             UploadError::IoError(e) => write!(f, "IO error: {}", e),
             UploadError::MultipartError(e) => write!(f, "Multipart error: {}", e),
@@ -154,13 +140,7 @@ pub async fn parse_multipart(
     boundary: &str,
     data: Bytes,
     config: &UploadConfig,
-) -> Result<
-    (
-        HashMap<String, Vec<String>>,
-        HashMap<String, Vec<UploadedFile>>,
-    ),
-    UploadError,
-> {
+) -> Result<(HashMap<String, Vec<String>>, HashMap<String, Vec<UploadedFile>>), UploadError> {
     let stream = futures_util::stream::once(async { Ok::<Bytes, std::io::Error>(data) });
     let mut multipart = Multipart::new(stream, boundary);
 
@@ -171,7 +151,7 @@ pub async fn parse_multipart(
     while let Some(field) = multipart.next_field().await? {
         let name = field.name().unwrap_or_default().to_string();
         let filename = field.file_name().map(|s| {
-            let s = s.split(['/', '\\']).last().unwrap_or(s);
+            let s = s.split(['/', '\\']).next_back().unwrap_or(s);
             s.to_string()
         });
         let content_type = field

--- a/packages/core/src/http/multipart.rs
+++ b/packages/core/src/http/multipart.rs
@@ -1,0 +1,50 @@
+use hyper::body::Bytes;
+use multer::Multipart;
+use std::collections::HashMap;
+use futures_util::stream::once;
+use std::convert::Infallible;
+
+#[derive(Clone, Debug)]
+pub struct UploadedFile {
+    pub filename: String,
+    pub content_type: String,
+    pub size: usize,
+    pub data: Bytes,
+}
+
+pub async fn parse_multipart(
+    boundary: &str,
+    data: Bytes,
+) -> Result<(HashMap<String, Vec<String>>, HashMap<String, Vec<UploadedFile>>), multer::Error> {
+    let stream = once(async move { Result::<Bytes, Infallible>::Ok(data) });
+    let mut multipart = Multipart::new(stream, boundary);
+
+    let mut fields: HashMap<String, Vec<String>> = HashMap::new();
+    let mut files: HashMap<String, Vec<UploadedFile>> = HashMap::new();
+
+    while let Some(field) = multipart.next_field().await? {
+        let name = field.name().unwrap_or_default().to_string();
+        let filename = field.file_name().map(|s| {
+            // Sanitize filename: remove path components
+            let s = s.split(['/', '\\']).last().unwrap_or(s);
+            s.to_string()
+        });
+        let content_type = field.content_type().map(|m| m.to_string()).unwrap_or_else(|| "application/octet-stream".to_string());
+
+        if let Some(filename) = filename {
+            let data = field.bytes().await?;
+            let size = data.len();
+            files.entry(name).or_default().push(UploadedFile {
+                filename,
+                content_type,
+                size,
+                data,
+            });
+        } else {
+            let value = field.text().await?;
+            fields.entry(name).or_default().push(value);
+        }
+    }
+
+    Ok((fields, files))
+}

--- a/packages/core/src/http/multipart_tests.rs
+++ b/packages/core/src/http/multipart_tests.rs
@@ -56,10 +56,7 @@ mod tests {
     #[test]
     fn test_extract_boundary_basic() {
         let ct = "multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW";
-        assert_eq!(
-            extract_boundary(ct),
-            Some("----WebKitFormBoundary7MA4YWxkTrZu0gW".to_string())
-        );
+        assert_eq!(extract_boundary(ct), Some("----WebKitFormBoundary7MA4YWxkTrZu0gW".to_string()));
     }
 
     #[test]
@@ -221,28 +218,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_parse_multipart_text_fields() {
-        let (boundary, body) = build_multipart_body(
-            &[("username", "john"), ("email", "john@example.com")],
-            &[],
-        );
+        let (boundary, body) =
+            build_multipart_body(&[("username", "john"), ("email", "john@example.com")], &[]);
 
         let (fields, files) = parse_multipart(&boundary, body, &default_config()).await.unwrap();
 
         assert_eq!(fields.get("username").unwrap(), &vec!["john".to_string()]);
-        assert_eq!(
-            fields.get("email").unwrap(),
-            &vec!["john@example.com".to_string()]
-        );
+        assert_eq!(fields.get("email").unwrap(), &vec!["john@example.com".to_string()]);
         assert!(files.is_empty());
     }
 
     #[tokio::test]
     async fn test_parse_multipart_single_file() {
         let file_content = b"hello world";
-        let (boundary, body) = build_multipart_body(
-            &[],
-            &[("avatar", "test.txt", "text/plain", file_content)],
-        );
+        let (boundary, body) =
+            build_multipart_body(&[], &[("avatar", "test.txt", "text/plain", file_content)]);
 
         let (fields, files) = parse_multipart(&boundary, body, &default_config()).await.unwrap();
 
@@ -288,10 +278,7 @@ mod tests {
 
         let (fields, files) = parse_multipart(&boundary, body, &default_config()).await.unwrap();
 
-        assert_eq!(
-            fields.get("description").unwrap(),
-            &vec!["my photo".to_string()]
-        );
+        assert_eq!(fields.get("description").unwrap(), &vec!["my photo".to_string()]);
         assert_eq!(files.len(), 1);
         assert_eq!(files.get("photo").unwrap()[0].filename, "image.png");
     }
@@ -441,10 +428,8 @@ mod tests {
         };
 
         let big_data: Vec<u8> = vec![b'x'; 100];
-        let (boundary, body) = build_multipart_body(
-            &[],
-            &[("file", "big.txt", "text/plain", &big_data)],
-        );
+        let (boundary, body) =
+            build_multipart_body(&[], &[("file", "big.txt", "text/plain", &big_data)]);
 
         let result = parse_multipart(&boundary, body, &config).await;
         assert!(result.is_err());
@@ -471,10 +456,7 @@ mod tests {
         let data2: Vec<u8> = vec![b'b'; 20];
         let (boundary, body) = build_multipart_body(
             &[],
-            &[
-                ("file1", "a.txt", "text/plain", &data1),
-                ("file2", "b.txt", "text/plain", &data2),
-            ],
+            &[("file1", "a.txt", "text/plain", &data1), ("file2", "b.txt", "text/plain", &data2)],
         );
 
         let result = parse_multipart(&boundary, body, &config).await;
@@ -598,10 +580,7 @@ mod tests {
 
     #[test]
     fn test_upload_error_display_total_limit() {
-        let err = UploadError::TotalSizeExceeded {
-            limit: 5000,
-            actual: 8000,
-        };
+        let err = UploadError::TotalSizeExceeded { limit: 5000, actual: 8000 };
         let msg = err.to_string();
         assert!(msg.contains("5000"));
         assert!(msg.contains("8000"));
@@ -609,10 +588,8 @@ mod tests {
 
     #[test]
     fn test_upload_error_is_std_error() {
-        let err = UploadError::IoError(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "test error",
-        ));
+        let err =
+            UploadError::IoError(std::io::Error::new(std::io::ErrorKind::Other, "test error"));
         let _: &dyn std::error::Error = &err;
     }
 }

--- a/packages/core/src/http/multipart_tests.rs
+++ b/packages/core/src/http/multipart_tests.rs
@@ -1,0 +1,618 @@
+#[cfg(test)]
+mod tests {
+    use super::super::multipart::*;
+    use hyper::body::Bytes;
+
+    fn default_config() -> UploadConfig {
+        UploadConfig::default()
+    }
+
+    fn small_file_config() -> UploadConfig {
+        UploadConfig {
+            memory_threshold: 1024,
+            max_file_size: 10 * 1024,
+            max_total_size: 50 * 1024,
+            temp_dir: None,
+        }
+    }
+
+    fn build_multipart_body(
+        fields: &[(&str, &str)],
+        files: &[(&str, &str, &str, &[u8])],
+    ) -> (String, Bytes) {
+        let boundary = "test-boundary-123";
+        let mut body = Vec::new();
+
+        for (name, value) in fields {
+            body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+            body.extend_from_slice(
+                format!("Content-Disposition: form-data; name=\"{}\"\r\n\r\n", name).as_bytes(),
+            );
+            body.extend_from_slice(value.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
+
+        for (name, filename, content_type, data) in files {
+            body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+            body.extend_from_slice(
+                format!(
+                    "Content-Disposition: form-data; name=\"{}\"; filename=\"{}\"\r\n",
+                    name, filename
+                )
+                .as_bytes(),
+            );
+            body.extend_from_slice(format!("Content-Type: {}\r\n\r\n", content_type).as_bytes());
+            body.extend_from_slice(data);
+            body.extend_from_slice(b"\r\n");
+        }
+
+        body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
+
+        (boundary.to_string(), Bytes::from(body))
+    }
+
+    // ===== extract_boundary tests =====
+
+    #[test]
+    fn test_extract_boundary_basic() {
+        let ct = "multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW";
+        assert_eq!(
+            extract_boundary(ct),
+            Some("----WebKitFormBoundary7MA4YWxkTrZu0gW".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_boundary_with_quotes() {
+        let ct = "multipart/form-data; boundary=\"my-boundary\"";
+        assert_eq!(extract_boundary(ct), Some("my-boundary".to_string()));
+    }
+
+    #[test]
+    fn test_extract_boundary_case_insensitive_content_type() {
+        let ct = "Multipart/Form-Data; boundary=abc123";
+        assert_eq!(extract_boundary(ct), Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn test_extract_boundary_case_insensitive_boundary_param() {
+        let ct = "multipart/form-data; Boundary=abc123";
+        assert_eq!(extract_boundary(ct), Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn test_extract_boundary_extra_params() {
+        let ct = "multipart/form-data; boundary=abc123; charset=UTF-8";
+        assert_eq!(extract_boundary(ct), Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn test_extract_boundary_not_multipart() {
+        let ct = "application/json";
+        assert_eq!(extract_boundary(ct), None);
+    }
+
+    #[test]
+    fn test_extract_boundary_multipart_no_boundary_param() {
+        let ct = "multipart/form-data";
+        assert_eq!(extract_boundary(ct), None);
+    }
+
+    #[test]
+    fn test_extract_boundary_empty_boundary() {
+        let ct = "multipart/form-data; boundary=";
+        assert_eq!(extract_boundary(ct), Some("".to_string()));
+    }
+
+    #[test]
+    fn test_extract_boundary_with_spaces_around_equals() {
+        let ct = "multipart/form-data; boundary = my-boundary";
+        assert_eq!(extract_boundary(ct), Some("my-boundary".to_string()));
+    }
+
+    #[test]
+    fn test_extract_boundary_with_quotes_and_spaces() {
+        let ct = "multipart/form-data; boundary = \"quoted-boundary\"";
+        assert_eq!(extract_boundary(ct), Some("quoted-boundary".to_string()));
+    }
+
+    // ===== UploadConfig tests =====
+
+    #[test]
+    fn test_upload_config_default() {
+        let config = UploadConfig::default();
+        assert_eq!(config.memory_threshold, 10 * 1024 * 1024);
+        assert_eq!(config.max_file_size, 100 * 1024 * 1024);
+        assert_eq!(config.max_total_size, 500 * 1024 * 1024);
+        assert!(config.temp_dir.is_none());
+    }
+
+    #[test]
+    fn test_upload_config_custom() {
+        let config = UploadConfig {
+            memory_threshold: 512,
+            max_file_size: 1024,
+            max_total_size: 2048,
+            temp_dir: Some("/tmp/uploads".to_string()),
+        };
+        assert_eq!(config.memory_threshold, 512);
+        assert_eq!(config.max_file_size, 1024);
+        assert_eq!(config.max_total_size, 2048);
+        assert_eq!(config.temp_dir.as_deref(), Some("/tmp/uploads"));
+    }
+
+    // ===== FileData tests =====
+
+    #[test]
+    fn test_file_data_memory() {
+        let data = FileData::Memory(Bytes::from("hello"));
+        assert!(data.is_memory());
+        assert!(!data.is_disk());
+        assert!(data.as_bytes().is_some());
+        assert_eq!(data.as_bytes().unwrap().as_ref(), b"hello");
+        assert!(data.path().is_none());
+    }
+
+    #[test]
+    fn test_file_data_disk() {
+        let data = FileData::Disk(std::path::PathBuf::from("/tmp/test.txt"));
+        assert!(!data.is_memory());
+        assert!(data.is_disk());
+        assert!(data.as_bytes().is_none());
+        assert_eq!(data.path(), Some(std::path::Path::new("/tmp/test.txt")));
+    }
+
+    #[test]
+    fn test_file_data_clone() {
+        let data = FileData::Memory(Bytes::from("test"));
+        let cloned = data.clone();
+        assert!(cloned.is_memory());
+        assert_eq!(cloned.as_bytes().unwrap().as_ref(), b"test");
+    }
+
+    // ===== UploadedFile tests =====
+
+    #[test]
+    fn test_uploaded_file_memory() {
+        let file = UploadedFile {
+            filename: "test.txt".to_string(),
+            content_type: "text/plain".to_string(),
+            size: 4,
+            data: FileData::Memory(Bytes::from("test")),
+        };
+
+        assert_eq!(file.filename, "test.txt");
+        assert_eq!(file.content_type, "text/plain");
+        assert_eq!(file.size, 4);
+        assert!(file.bytes().is_some());
+        assert_eq!(file.bytes().unwrap().as_ref(), b"test");
+        assert!(file.path().is_none());
+    }
+
+    #[test]
+    fn test_uploaded_file_disk() {
+        let file = UploadedFile {
+            filename: "large.bin".to_string(),
+            content_type: "application/octet-stream".to_string(),
+            size: 1024,
+            data: FileData::Disk(std::path::PathBuf::from("/tmp/large.bin")),
+        };
+
+        assert_eq!(file.filename, "large.bin");
+        assert!(file.bytes().is_none());
+        assert_eq!(file.path(), Some(std::path::Path::new("/tmp/large.bin")));
+    }
+
+    #[test]
+    fn test_uploaded_file_debug() {
+        let file = UploadedFile {
+            filename: "debug.txt".to_string(),
+            content_type: "text/plain".to_string(),
+            size: 5,
+            data: FileData::Memory(Bytes::from("hello")),
+        };
+
+        let debug_str = format!("{:?}", file);
+        assert!(debug_str.contains("debug.txt"));
+        assert!(debug_str.contains("text/plain"));
+    }
+
+    // ===== parse_multipart tests (in-memory) =====
+
+    #[tokio::test]
+    async fn test_parse_multipart_text_fields() {
+        let (boundary, body) = build_multipart_body(
+            &[("username", "john"), ("email", "john@example.com")],
+            &[],
+        );
+
+        let (fields, files) = parse_multipart(&boundary, body, &default_config()).await.unwrap();
+
+        assert_eq!(fields.get("username").unwrap(), &vec!["john".to_string()]);
+        assert_eq!(
+            fields.get("email").unwrap(),
+            &vec!["john@example.com".to_string()]
+        );
+        assert!(files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_single_file() {
+        let file_content = b"hello world";
+        let (boundary, body) = build_multipart_body(
+            &[],
+            &[("avatar", "test.txt", "text/plain", file_content)],
+        );
+
+        let (fields, files) = parse_multipart(&boundary, body, &default_config()).await.unwrap();
+
+        assert!(fields.is_empty());
+        assert_eq!(files.len(), 1);
+
+        let avatar_files = files.get("avatar").unwrap();
+        assert_eq!(avatar_files.len(), 1);
+
+        let file = &avatar_files[0];
+        assert_eq!(file.filename, "test.txt");
+        assert_eq!(file.content_type, "text/plain");
+        assert_eq!(file.size, file_content.len());
+        assert!(file.data.is_memory());
+        assert_eq!(file.bytes().unwrap().as_ref(), file_content);
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_multiple_files_same_field() {
+        let (boundary, body) = build_multipart_body(
+            &[],
+            &[
+                ("docs", "a.txt", "text/plain", b"content a"),
+                ("docs", "b.txt", "text/plain", b"content b"),
+            ],
+        );
+
+        let (fields, files) = parse_multipart(&boundary, body, &default_config()).await.unwrap();
+
+        assert!(fields.is_empty());
+        let doc_files = files.get("docs").unwrap();
+        assert_eq!(doc_files.len(), 2);
+        assert_eq!(doc_files[0].filename, "a.txt");
+        assert_eq!(doc_files[1].filename, "b.txt");
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_mixed_fields_and_files() {
+        let (boundary, body) = build_multipart_body(
+            &[("description", "my photo")],
+            &[("photo", "image.png", "image/png", b"png-data")],
+        );
+
+        let (fields, files) = parse_multipart(&boundary, body, &default_config()).await.unwrap();
+
+        assert_eq!(
+            fields.get("description").unwrap(),
+            &vec!["my photo".to_string()]
+        );
+        assert_eq!(files.len(), 1);
+        assert_eq!(files.get("photo").unwrap()[0].filename, "image.png");
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_filename_strips_path() {
+        let boundary = "test-boundary-123";
+        let body = Bytes::from(
+            format!(
+                "--{b}\r\n\
+                 Content-Disposition: form-data; name=\"file\"; filename=\"/etc/passwd\"\r\n\
+                 Content-Type: text/plain\r\n\
+                 \r\n\
+                 data\r\n\
+                 --{b}--\r\n",
+                b = boundary
+            )
+            .as_bytes()
+            .to_vec(),
+        );
+
+        let (_, files) = parse_multipart(boundary, body, &default_config()).await.unwrap();
+        let file = &files.get("file").unwrap()[0];
+        assert_eq!(file.filename, "passwd");
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_filename_strips_backslash() {
+        let boundary = "test-boundary-123";
+        let body = Bytes::from(
+            format!(
+                "--{b}\r\n\
+                 Content-Disposition: form-data; name=\"file\"; filename=\"C:\\\\Users\\\\test.txt\"\r\n\
+                 Content-Type: text/plain\r\n\
+                 \r\n\
+                 data\r\n\
+                 --{b}--\r\n",
+                b = boundary
+            )
+            .as_bytes()
+            .to_vec(),
+        );
+
+        let (_, files) = parse_multipart(boundary, body, &default_config()).await.unwrap();
+        let file = &files.get("file").unwrap()[0];
+        assert_eq!(file.filename, "test.txt");
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_default_content_type() {
+        let boundary = "test-boundary-123";
+        let body = Bytes::from(
+            format!(
+                "--{b}\r\n\
+                 Content-Disposition: form-data; name=\"file\"; filename=\"data.bin\"\r\n\
+                 \r\n\
+                 binary-data\r\n\
+                 --{b}--\r\n",
+                b = boundary
+            )
+            .as_bytes()
+            .to_vec(),
+        );
+
+        let (_, files) = parse_multipart(boundary, body, &default_config()).await.unwrap();
+        let file = &files.get("file").unwrap()[0];
+        assert_eq!(file.content_type, "application/octet-stream");
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_empty_body() {
+        let boundary = "test-boundary-123";
+        let body = Bytes::from(format!("--{b}--\r\n", b = boundary).as_bytes().to_vec());
+
+        let (fields, files) = parse_multipart(boundary, body, &default_config()).await.unwrap();
+        assert!(fields.is_empty());
+        assert!(files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_invalid_boundary() {
+        let body = Bytes::from(b"some random data that is not multipart".to_vec());
+        let result = parse_multipart("wrong-boundary", body, &default_config()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_duplicate_text_fields() {
+        let boundary = "test-boundary-123";
+        let body = Bytes::from(
+            format!(
+                "--{b}\r\n\
+                 Content-Disposition: form-data; name=\"tag\"\r\n\
+                 \r\n\
+                 rust\r\n\
+                 --{b}\r\n\
+                 Content-Disposition: form-data; name=\"tag\"\r\n\
+                 \r\n\
+                 web\r\n\
+                 --{b}--\r\n",
+                b = boundary
+            )
+            .as_bytes()
+            .to_vec(),
+        );
+
+        let (fields, _) = parse_multipart(boundary, body, &default_config()).await.unwrap();
+        let tags = fields.get("tag").unwrap();
+        assert_eq!(tags, &vec!["rust".to_string(), "web".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_binary_file() {
+        let binary_data: Vec<u8> = (0..=255).collect();
+        let (boundary, body) = build_multipart_body(
+            &[],
+            &[("data", "bytes.bin", "application/octet-stream", &binary_data)],
+        );
+
+        let (_, files) = parse_multipart(&boundary, body, &default_config()).await.unwrap();
+        let file = &files.get("data").unwrap()[0];
+        assert_eq!(file.size, 256);
+        assert!(file.data.is_memory());
+        assert_eq!(file.bytes().unwrap().as_ref(), binary_data.as_slice());
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_empty_file() {
+        let (boundary, body) =
+            build_multipart_body(&[], &[("empty", "empty.txt", "text/plain", b"")]);
+
+        let (_, files) = parse_multipart(&boundary, body, &default_config()).await.unwrap();
+        let file = &files.get("empty").unwrap()[0];
+        assert_eq!(file.size, 0);
+        assert!(file.bytes().unwrap().is_empty());
+    }
+
+    // ===== Size limit tests =====
+
+    #[tokio::test]
+    async fn test_parse_multipart_file_exceeds_max_size() {
+        let config = UploadConfig {
+            memory_threshold: 1024,
+            max_file_size: 50,
+            max_total_size: 1024 * 1024,
+            temp_dir: None,
+        };
+
+        let big_data: Vec<u8> = vec![b'x'; 100];
+        let (boundary, body) = build_multipart_body(
+            &[],
+            &[("file", "big.txt", "text/plain", &big_data)],
+        );
+
+        let result = parse_multipart(&boundary, body, &config).await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            UploadError::SizeLimitExceeded { field, limit, actual } => {
+                assert_eq!(field, "file");
+                assert_eq!(limit, 50);
+                assert!(actual > 50);
+            }
+            _ => panic!("Expected SizeLimitExceeded error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_total_size_exceeded() {
+        let config = UploadConfig {
+            memory_threshold: 1024,
+            max_file_size: 1024 * 1024,
+            max_total_size: 30,
+            temp_dir: None,
+        };
+
+        let data1: Vec<u8> = vec![b'a'; 20];
+        let data2: Vec<u8> = vec![b'b'; 20];
+        let (boundary, body) = build_multipart_body(
+            &[],
+            &[
+                ("file1", "a.txt", "text/plain", &data1),
+                ("file2", "b.txt", "text/plain", &data2),
+            ],
+        );
+
+        let result = parse_multipart(&boundary, body, &config).await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            UploadError::TotalSizeExceeded { limit, actual } => {
+                assert_eq!(limit, 30);
+                assert!(actual > 30);
+            }
+            _ => panic!("Expected TotalSizeExceeded error"),
+        }
+    }
+
+    // ===== Temp file tests =====
+
+    #[tokio::test]
+    async fn test_parse_multipart_large_file_to_disk() {
+        let config = small_file_config();
+
+        let large_data: Vec<u8> = vec![42u8; 2048];
+        let (boundary, body) = build_multipart_body(
+            &[],
+            &[("file", "large.bin", "application/octet-stream", &large_data)],
+        );
+
+        let (_, files) = parse_multipart(&boundary, body, &config).await.unwrap();
+        let file = &files.get("file").unwrap()[0];
+
+        assert_eq!(file.size, 2048);
+        assert!(file.data.is_disk());
+        assert!(file.path().is_some());
+        assert!(file.bytes().is_none());
+
+        let path = file.path().unwrap();
+        assert!(path.exists());
+
+        let content = tokio::fs::read(path).await.unwrap();
+        assert_eq!(content, large_data);
+
+        crate::http::multipart::cleanup_files(&files);
+    }
+
+    #[tokio::test]
+    async fn test_parse_multipart_mixed_memory_and_disk() {
+        let config = UploadConfig {
+            memory_threshold: 100,
+            max_file_size: 10 * 1024,
+            max_total_size: 50 * 1024,
+            temp_dir: None,
+        };
+
+        let small_data = b"small";
+        let large_data: Vec<u8> = vec![42u8; 200];
+
+        let boundary = "test-boundary-123";
+        let body = Bytes::from(
+            format!(
+                "--{b}\r\n\
+                 Content-Disposition: form-data; name=\"small\"; filename=\"small.txt\"\r\n\
+                 Content-Type: text/plain\r\n\
+                 \r\n\
+                 {s}\r\n\
+                 --{b}\r\n\
+                 Content-Disposition: form-data; name=\"large\"; filename=\"large.bin\"\r\n\
+                 Content-Type: application/octet-stream\r\n\
+                 \r\n\
+                 {l}\r\n\
+                 --{b}--\r\n",
+                b = boundary,
+                s = std::str::from_utf8(small_data).unwrap(),
+                l = String::from_utf8(large_data.clone()).unwrap(),
+            )
+            .into_bytes(),
+        );
+
+        let (_, files) = parse_multipart(boundary, body, &config).await.unwrap();
+
+        let small_file = &files.get("small").unwrap()[0];
+        assert!(small_file.data.is_memory());
+        assert_eq!(small_file.bytes().unwrap().as_ref(), small_data);
+
+        let large_file = &files.get("large").unwrap()[0];
+        assert!(large_file.data.is_disk());
+
+        crate::http::multipart::cleanup_files(&files);
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_files_removes_disk_files() {
+        let config = small_file_config();
+
+        let large_data: Vec<u8> = vec![42u8; 2048];
+        let (boundary, body) = build_multipart_body(
+            &[],
+            &[("file", "temp.bin", "application/octet-stream", &large_data)],
+        );
+
+        let (_, files) = parse_multipart(&boundary, body, &config).await.unwrap();
+        let file = &files.get("file").unwrap()[0];
+        let path = file.path().unwrap().to_path_buf();
+
+        assert!(path.exists());
+        crate::http::multipart::cleanup_files(&files);
+        assert!(!path.exists());
+    }
+
+    // ===== UploadError tests =====
+
+    #[test]
+    fn test_upload_error_display_size_limit() {
+        let err = UploadError::SizeLimitExceeded {
+            field: "avatar".to_string(),
+            limit: 1024,
+            actual: 2048,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("avatar"));
+        assert!(msg.contains("1024"));
+        assert!(msg.contains("2048"));
+    }
+
+    #[test]
+    fn test_upload_error_display_total_limit() {
+        let err = UploadError::TotalSizeExceeded {
+            limit: 5000,
+            actual: 8000,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("5000"));
+        assert!(msg.contains("8000"));
+    }
+
+    #[test]
+    fn test_upload_error_is_std_error() {
+        let err = UploadError::IoError(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "test error",
+        ));
+        let _: &dyn std::error::Error = &err;
+    }
+}

--- a/packages/core/src/http/request.rs
+++ b/packages/core/src/http/request.rs
@@ -7,6 +7,7 @@ use hyper::{
 use napi::bindgen_prelude::{Buffer, External};
 
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+use crate::http::multipart::{parse_multipart, UploadedFile};
 
 #[derive(Clone)]
 pub struct RequestCore {
@@ -27,6 +28,7 @@ pub struct RequestCore {
     pub params: HashMap<String, String>,
     pub query_raw: HashMap<String, Vec<String>>,
     pub cookies_raw: HashMap<String, String>,
+    pub files: HashMap<String, Vec<UploadedFile>>,
 }
 
 impl RequestCore {
@@ -108,6 +110,37 @@ impl RequestCore {
         let xhr =
             headers_raw.get("x-requested-with").map(|v| v == "XMLHttpRequest").unwrap_or(false);
 
+        let mut files = HashMap::new();
+        if let Some(content_type) = headers_raw.get("content-type") {
+            if content_type.to_lowercase().starts_with("multipart/form-data") {
+                let boundary = content_type
+                    .split(';')
+                    .find_map(|s| {
+                        let s = s.trim();
+                        if s.to_lowercase().starts_with("boundary=") {
+                            let b = &s[9..];
+                            Some(b.trim_matches('"').to_string())
+                        } else {
+                            None
+                        }
+                    });
+
+                if let Some(boundary) = boundary {
+                    match parse_multipart(&boundary, body.clone()).await {
+                        Ok((fields, parsed_files)) => {
+                            for (key, values) in fields {
+                                query_raw.entry(key).or_default().extend(values);
+                            }
+                            files = parsed_files;
+                        }
+                        Err(e) => {
+                            eprintln!("Error parsing multipart body: {}", e);
+                        }
+                    }
+                }
+            }
+        }
+
         Ok(Self {
             method,
             url,
@@ -125,6 +158,7 @@ impl RequestCore {
             params: HashMap::new(),
             query_raw,
             cookies_raw,
+            files,
         })
     }
 }
@@ -222,4 +256,45 @@ pub fn get_secure(core: &External<Arc<RequestCore>>) -> bool {
 #[napi]
 pub fn get_xhr(core: &External<Arc<RequestCore>>) -> bool {
     core.xhr
+}
+
+#[napi(object)]
+pub struct UploadedFileNapi {
+    pub filename: String,
+    pub content_type: String,
+    pub size: u32,
+    pub data: Buffer,
+}
+
+#[napi]
+pub fn get_all_files(core: &External<Arc<RequestCore>>) -> HashMap<String, Vec<UploadedFileNapi>> {
+    let mut files = HashMap::new();
+    for (key, file_list) in &core.files {
+        let napi_files: Vec<UploadedFileNapi> = file_list
+            .iter()
+            .map(|f| UploadedFileNapi {
+                filename: f.filename.clone(),
+                content_type: f.content_type.clone(),
+                size: f.size as u32,
+                data: Buffer::from(f.data.as_ref()),
+            })
+            .collect();
+        files.insert(key.clone(), napi_files);
+    }
+    files
+}
+
+#[napi]
+pub fn get_file(core: &External<Arc<RequestCore>>, name: String) -> Option<Vec<UploadedFileNapi>> {
+    core.files.get(&name).map(|file_list| {
+        file_list
+            .iter()
+            .map(|f| UploadedFileNapi {
+                filename: f.filename.clone(),
+                content_type: f.content_type.clone(),
+                size: f.size as u32,
+                data: Buffer::from(f.data.as_ref()),
+            })
+            .collect()
+    })
 }

--- a/packages/core/src/http/request.rs
+++ b/packages/core/src/http/request.rs
@@ -6,10 +6,10 @@ use hyper::{
 
 use napi::bindgen_prelude::{Buffer, External};
 
-use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 use crate::http::multipart::{
-    extract_boundary, parse_multipart, FileData, UploadConfig, UploadedFile,
+    FileData, UploadConfig, UploadedFile, extract_boundary, parse_multipart,
 };
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 #[derive(Clone)]
 pub struct RequestCore {
@@ -122,18 +122,18 @@ impl RequestCore {
             headers_raw.get("x-requested-with").map(|v| v == "XMLHttpRequest").unwrap_or(false);
 
         let mut files = HashMap::new();
-        if let Some(content_type) = headers_raw.get("content-type") {
-            if let Some(boundary) = extract_boundary(content_type) {
-                match parse_multipart(&boundary, body.clone(), upload_config).await {
-                    Ok((fields, parsed_files)) => {
-                        for (key, values) in fields {
-                            query_raw.entry(key).or_default().extend(values);
-                        }
-                        files = parsed_files;
+        if let Some(content_type) = headers_raw.get("content-type")
+            && let Some(boundary) = extract_boundary(content_type)
+        {
+            match parse_multipart(&boundary, body.clone(), upload_config).await {
+                Ok((fields, parsed_files)) => {
+                    for (key, values) in fields {
+                        query_raw.entry(key).or_default().extend(values);
                     }
-                    Err(e) => {
-                        eprintln!("Error parsing multipart body: {}", e);
-                    }
+                    files = parsed_files;
+                }
+                Err(e) => {
+                    eprintln!("Error parsing multipart body: {}", e);
                 }
             }
         }
@@ -274,11 +274,9 @@ pub fn get_all_files(core: &External<Arc<RequestCore>>) -> HashMap<String, Vec<U
             .map(|f| {
                 let (data, file_path, is_disk) = match &f.data {
                     FileData::Memory(b) => (Buffer::from(b.as_ref()), String::new(), false),
-                    FileData::Disk(p) => (
-                        Buffer::from(&[] as &[u8]),
-                        p.to_string_lossy().to_string(),
-                        true,
-                    ),
+                    FileData::Disk(p) => {
+                        (Buffer::from(&[] as &[u8]), p.to_string_lossy().to_string(), true)
+                    }
                 };
                 UploadedFileNapi {
                     filename: f.filename.clone(),
@@ -303,11 +301,9 @@ pub fn get_file(core: &External<Arc<RequestCore>>, name: String) -> Option<Vec<U
             .map(|f| {
                 let (data, file_path, is_disk) = match &f.data {
                     FileData::Memory(b) => (Buffer::from(b.as_ref()), String::new(), false),
-                    FileData::Disk(p) => (
-                        Buffer::from(&[] as &[u8]),
-                        p.to_string_lossy().to_string(),
-                        true,
-                    ),
+                    FileData::Disk(p) => {
+                        (Buffer::from(&[] as &[u8]), p.to_string_lossy().to_string(), true)
+                    }
                 };
                 UploadedFileNapi {
                     filename: f.filename.clone(),

--- a/packages/core/src/http/request.rs
+++ b/packages/core/src/http/request.rs
@@ -7,7 +7,9 @@ use hyper::{
 use napi::bindgen_prelude::{Buffer, External};
 
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
-use crate::http::multipart::{parse_multipart, UploadedFile};
+use crate::http::multipart::{
+    extract_boundary, parse_multipart, FileData, UploadConfig, UploadedFile,
+};
 
 #[derive(Clone)]
 pub struct RequestCore {
@@ -36,6 +38,15 @@ impl RequestCore {
         req: Request<Incoming>,
         remote_addr: Option<SocketAddr>,
         trust_proxy: bool,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        Self::new_with_config(req, remote_addr, trust_proxy, &UploadConfig::default()).await
+    }
+
+    pub async fn new_with_config(
+        req: Request<Incoming>,
+        remote_addr: Option<SocketAddr>,
+        trust_proxy: bool,
+        upload_config: &UploadConfig,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let method = req.method().as_str().to_string();
         let uri = req.uri();
@@ -112,30 +123,16 @@ impl RequestCore {
 
         let mut files = HashMap::new();
         if let Some(content_type) = headers_raw.get("content-type") {
-            if content_type.to_lowercase().starts_with("multipart/form-data") {
-                let boundary = content_type
-                    .split(';')
-                    .find_map(|s| {
-                        let s = s.trim();
-                        if s.to_lowercase().starts_with("boundary=") {
-                            let b = &s[9..];
-                            Some(b.trim_matches('"').to_string())
-                        } else {
-                            None
+            if let Some(boundary) = extract_boundary(content_type) {
+                match parse_multipart(&boundary, body.clone(), upload_config).await {
+                    Ok((fields, parsed_files)) => {
+                        for (key, values) in fields {
+                            query_raw.entry(key).or_default().extend(values);
                         }
-                    });
-
-                if let Some(boundary) = boundary {
-                    match parse_multipart(&boundary, body.clone()).await {
-                        Ok((fields, parsed_files)) => {
-                            for (key, values) in fields {
-                                query_raw.entry(key).or_default().extend(values);
-                            }
-                            files = parsed_files;
-                        }
-                        Err(e) => {
-                            eprintln!("Error parsing multipart body: {}", e);
-                        }
+                        files = parsed_files;
+                    }
+                    Err(e) => {
+                        eprintln!("Error parsing multipart body: {}", e);
                     }
                 }
             }
@@ -264,6 +261,8 @@ pub struct UploadedFileNapi {
     pub content_type: String,
     pub size: u32,
     pub data: Buffer,
+    pub file_path: String,
+    pub is_disk: bool,
 }
 
 #[napi]
@@ -272,11 +271,23 @@ pub fn get_all_files(core: &External<Arc<RequestCore>>) -> HashMap<String, Vec<U
     for (key, file_list) in &core.files {
         let napi_files: Vec<UploadedFileNapi> = file_list
             .iter()
-            .map(|f| UploadedFileNapi {
-                filename: f.filename.clone(),
-                content_type: f.content_type.clone(),
-                size: f.size as u32,
-                data: Buffer::from(f.data.as_ref()),
+            .map(|f| {
+                let (data, file_path, is_disk) = match &f.data {
+                    FileData::Memory(b) => (Buffer::from(b.as_ref()), String::new(), false),
+                    FileData::Disk(p) => (
+                        Buffer::from(&[] as &[u8]),
+                        p.to_string_lossy().to_string(),
+                        true,
+                    ),
+                };
+                UploadedFileNapi {
+                    filename: f.filename.clone(),
+                    content_type: f.content_type.clone(),
+                    size: f.size as u32,
+                    data,
+                    file_path,
+                    is_disk,
+                }
             })
             .collect();
         files.insert(key.clone(), napi_files);
@@ -289,12 +300,61 @@ pub fn get_file(core: &External<Arc<RequestCore>>, name: String) -> Option<Vec<U
     core.files.get(&name).map(|file_list| {
         file_list
             .iter()
-            .map(|f| UploadedFileNapi {
-                filename: f.filename.clone(),
-                content_type: f.content_type.clone(),
-                size: f.size as u32,
-                data: Buffer::from(f.data.as_ref()),
+            .map(|f| {
+                let (data, file_path, is_disk) = match &f.data {
+                    FileData::Memory(b) => (Buffer::from(b.as_ref()), String::new(), false),
+                    FileData::Disk(p) => (
+                        Buffer::from(&[] as &[u8]),
+                        p.to_string_lossy().to_string(),
+                        true,
+                    ),
+                };
+                UploadedFileNapi {
+                    filename: f.filename.clone(),
+                    content_type: f.content_type.clone(),
+                    size: f.size as u32,
+                    data,
+                    file_path,
+                    is_disk,
+                }
             })
             .collect()
     })
+}
+
+#[napi]
+pub fn get_file_path(core: &External<Arc<RequestCore>>, name: String) -> Option<String> {
+    core.files.get(&name).and_then(|file_list| {
+        file_list.first().and_then(|f| match &f.data {
+            FileData::Disk(p) => Some(p.to_string_lossy().to_string()),
+            FileData::Memory(_) => None,
+        })
+    })
+}
+
+#[napi]
+pub fn get_file_paths(core: &External<Arc<RequestCore>>) -> HashMap<String, Vec<String>> {
+    let mut paths = HashMap::new();
+    for (key, file_list) in &core.files {
+        let file_paths: Vec<String> = file_list
+            .iter()
+            .filter_map(|f| match &f.data {
+                FileData::Disk(p) => Some(p.to_string_lossy().to_string()),
+                FileData::Memory(_) => None,
+            })
+            .collect();
+        if !file_paths.is_empty() {
+            paths.insert(key.clone(), file_paths);
+        }
+    }
+    paths
+}
+
+#[napi]
+pub fn is_file_on_disk(core: &External<Arc<RequestCore>>, name: String) -> bool {
+    core.files
+        .get(&name)
+        .and_then(|file_list| file_list.first())
+        .map(|f| f.data.is_disk())
+        .unwrap_or(false)
 }

--- a/packages/kitojs/src/server/request.ts
+++ b/packages/kitojs/src/server/request.ts
@@ -3,6 +3,8 @@ import type {
   CommonHeaderNames,
   KitoRequest,
   RequestHeaders,
+  RequestFiles,
+  UploadedFile,
 } from "@kitojs/types";
 import {
   getBodyBuffer,
@@ -24,6 +26,7 @@ import {
   getIps,
   getSecure,
   getXhr,
+  getAllFiles,
 } from "@kitojs/kito-core";
 
 export class RequestBuilder implements KitoRequest {
@@ -46,6 +49,7 @@ export class RequestBuilder implements KitoRequest {
   private _ips?: string[];
   private _secure?: boolean;
   private _xhr?: boolean;
+  private _files?: RequestFiles;
 
   // biome-ignore lint/suspicious/noExplicitAny: ...
   constructor(requestCore: any) {
@@ -213,6 +217,25 @@ export class RequestBuilder implements KitoRequest {
       this._xhr = getXhr(this.core);
     }
     return this._xhr;
+  }
+
+  get files(): RequestFiles | undefined {
+    if (!this._files) {
+      const coreFiles = getAllFiles(this.core);
+      if (Object.keys(coreFiles).length === 0) return undefined;
+
+      this._files = {};
+      for (const [key, files] of Object.entries(coreFiles)) {
+        const mappedFiles: UploadedFile[] = (files as any[]).map((f) => ({
+          filename: f.filename,
+          contentType: f.contentType,
+          size: f.size,
+          data: f.data,
+        }));
+        this._files[key] = mappedFiles.length === 1 ? mappedFiles[0] : mappedFiles;
+      }
+    }
+    return this._files;
   }
 
   get originalUrl(): string {

--- a/packages/kitojs/src/server/request.ts
+++ b/packages/kitojs/src/server/request.ts
@@ -231,6 +231,8 @@ export class RequestBuilder implements KitoRequest {
           contentType: f.contentType,
           size: f.size,
           data: f.data,
+          filePath: f.filePath,
+          isDisk: f.isDisk,
         }));
         this._files[key] = mappedFiles.length === 1 ? mappedFiles[0] : mappedFiles;
       }

--- a/packages/types/src/http/request.d.ts
+++ b/packages/types/src/http/request.d.ts
@@ -47,6 +47,15 @@ export interface UploadedFile {
   contentType: string;
   size: number;
   data: Buffer;
+  filePath: string;
+  isDisk: boolean;
+}
+
+export interface UploadConfig {
+  memoryThreshold?: number;
+  maxFileSize?: number;
+  maxTotalSize?: number;
+  tempDir?: string;
 }
 
 export interface RequestFiles {

--- a/packages/types/src/http/request.d.ts
+++ b/packages/types/src/http/request.d.ts
@@ -42,6 +42,17 @@ export interface ParsedUrl {
   query: Record<string, string | string[]>;
 }
 
+export interface UploadedFile {
+  filename: string;
+  contentType: string;
+  size: number;
+  data: Buffer;
+}
+
+export interface RequestFiles {
+  [fieldName: string]: UploadedFile | UploadedFile[];
+}
+
 export interface KitoRequest {
   get method(): string;
   get url(): string;
@@ -61,6 +72,7 @@ export interface KitoRequest {
   get secure(): boolean;
   get xhr(): boolean;
   get originalUrl(): string;
+  get files(): RequestFiles | undefined;
 
   header(name: CommonHeaderNames): string | undefined;
   header(name: string): string | undefined;


### PR DESCRIPTION
## Summary
- Add multipart/form-data parsing with streaming support using `multer` crate
- Implement `UploadConfig` with configurable size limits (per-file and total)
- Files below 10MB stay in memory; larger files spill to temp files on disk
- Add `tempfile` dependency for safe temp file handling

## Changes
- `packages/core/src/http/multipart.rs` - New streaming parser with `FileData` enum (Memory/Disk)
- `packages/core/src/http/request.rs` - Integrate multipart parsing with upload config
- `packages/types/src/http/request.d.ts` - Add `filePath`, `isDisk` fields to `UploadedFile`
- `packages/kitojs/src/server/request.ts` - Update RequestBuilder for new file properties

## Testing
- 83 Rust tests (including 38 new multipart tests)
- 79 TypeScript tests
- All passing 